### PR TITLE
Remove Status bar translucency

### DIFF
--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -23,7 +23,7 @@
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light" />
 
     <style name="NoToolbarTheme.TranslucentBars">
-        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
         <item name="android:windowTranslucentNavigation">true</item>
     </style>
 


### PR DESCRIPTION
This removes the status bar translucency that caused the toolbar in the discover page to look like it isn't performing the set behaviour